### PR TITLE
Add EIN field support

### DIFF
--- a/lib/employer_identification_number_formatter.js
+++ b/lib/employer_identification_number_formatter.js
@@ -1,0 +1,75 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var _delimited_text_formatter = require('./delimited_text_formatter');
+
+var _delimited_text_formatter2 = _interopRequireDefault(_delimited_text_formatter);
+
+/**
+ * @const
+ * @private
+ */
+var DIGITS_PATTERN = /^\d*$/;
+
+/**
+ * @extends DelimitedTextFormatter
+ */
+
+var EmployerIdentificationNumberFormatter = (function (_DelimitedTextFormatter) {
+  _inherits(EmployerIdentificationNumberFormatter, _DelimitedTextFormatter);
+
+  function EmployerIdentificationNumberFormatter() {
+    _classCallCheck(this, EmployerIdentificationNumberFormatter);
+
+    _get(Object.getPrototypeOf(EmployerIdentificationNumberFormatter.prototype), 'constructor', this).call(this, '-');
+    this.maximumLength = 9 + 1;
+  }
+
+  /**
+   * @param {number} index
+   * @returns {boolean}
+   */
+
+  _createClass(EmployerIdentificationNumberFormatter, [{
+    key: 'hasDelimiterAtIndex',
+    value: function hasDelimiterAtIndex(index) {
+      return index === 2;
+    }
+
+    /**
+     * Determines whether the given change should be allowed and, if so, whether
+     * it should be altered.
+     *
+     * @param {TextFieldStateChange} change
+     * @param {function(string)} error
+     * @returns {boolean}
+     */
+  }, {
+    key: 'isChangeValid',
+    value: function isChangeValid(change, error) {
+      if (DIGITS_PATTERN.test(change.inserted.text)) {
+        return _get(Object.getPrototypeOf(EmployerIdentificationNumberFormatter.prototype), 'isChangeValid', this).call(this, change, error);
+      } else {
+        return false;
+      }
+    }
+  }]);
+
+  return EmployerIdentificationNumberFormatter;
+})(_delimited_text_formatter2['default']);
+
+exports['default'] = EmployerIdentificationNumberFormatter;
+module.exports = exports['default'];

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,10 @@ var _delimited_text_formatter = require('./delimited_text_formatter');
 
 var _delimited_text_formatter2 = _interopRequireDefault(_delimited_text_formatter);
 
+var _employer_identification_number_formatter = require('./employer_identification_number_formatter');
+
+var _employer_identification_number_formatter2 = _interopRequireDefault(_employer_identification_number_formatter);
+
 var _expiry_date_field = require('./expiry_date_field');
 
 var _expiry_date_field2 = _interopRequireDefault(_expiry_date_field);
@@ -79,6 +83,7 @@ module.exports = {
   },
   DefaultCardFormatter: _default_card_formatter2['default'],
   DelimitedTextFormatter: _delimited_text_formatter2['default'],
+  EmployerIdentificationNumberFormatter: _employer_identification_number_formatter2['default'],
   ExpiryDateField: _expiry_date_field2['default'],
   ExpiryDateFormatter: _expiry_date_formatter2['default'],
   Formatter: _formatter2['default'],

--- a/src/employer_identification_number_formatter.js
+++ b/src/employer_identification_number_formatter.js
@@ -1,0 +1,43 @@
+import DelimitedTextFormatter from './delimited_text_formatter';
+
+/**
+ * @const
+ * @private
+ */
+const DIGITS_PATTERN = /^\d*$/;
+
+/**
+ * @extends DelimitedTextFormatter
+ */
+class EmployerIdentificationNumberFormatter extends DelimitedTextFormatter {
+  constructor() {
+    super('-');
+    this.maximumLength = 9 + 1;
+  }
+
+  /**
+   * @param {number} index
+   * @returns {boolean}
+   */
+  hasDelimiterAtIndex(index) {
+    return index === 2;
+  }
+
+  /**
+   * Determines whether the given change should be allowed and, if so, whether
+   * it should be altered.
+   *
+   * @param {TextFieldStateChange} change
+   * @param {function(string)} error
+   * @returns {boolean}
+   */
+  isChangeValid(change, error) {
+    if (DIGITS_PATTERN.test(change.inserted.text)) {
+      return super.isChangeValid(change, error);
+    } else {
+      return false;
+    }
+  }
+}
+
+export default EmployerIdentificationNumberFormatter;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import CardTextField from './card_text_field';
 import { AMEX, DISCOVER, VISA, MASTERCARD, determineCardType, luhnCheck, validCardLength } from './card_utils';
 import DefaultCardFormatter from './default_card_formatter';
 import DelimitedTextFormatter from './delimited_text_formatter';
+import EmployerIdentificationNumberFormatter from './employer_identification_number_formatter';
 import ExpiryDateField from './expiry_date_field';
 import ExpiryDateFormatter from './expiry_date_formatter';
 import Formatter from './formatter';
@@ -33,6 +34,7 @@ module.exports = {
   },
   DefaultCardFormatter: DefaultCardFormatter,
   DelimitedTextFormatter: DelimitedTextFormatter,
+  EmployerIdentificationNumberFormatter: EmployerIdentificationNumberFormatter,
   ExpiryDateField: ExpiryDateField,
   ExpiryDateFormatter: ExpiryDateFormatter,
   Formatter: Formatter,

--- a/test/selenium/employer_identification_number_formatter_test.js
+++ b/test/selenium/employer_identification_number_formatter_test.js
@@ -1,0 +1,60 @@
+var By = require('selenium-webdriver').By;
+var Key = require('selenium-webdriver').Key;
+var until = require('selenium-webdriver').until;
+var test = require('selenium-webdriver/testing');
+var expect = require('chai').expect;
+var server = require('./server');
+var helpers = require('./helpers');
+
+test.describe('FieldKit.EmployerIdentificationNumberFormatter', function() {
+  var input;
+  test.beforeEach(function() {
+    server.goTo('employer_identification_number_formatter.html');
+    input = driver.findElement(By.tagName('input'));
+  });
+
+  test.it('places dashes in the right places', function() {
+    helpers.setInput('|', input);
+
+    input.sendKeys('123456789');
+
+    return helpers.getFieldKitValues()
+      .then(function(values) {
+        expect(values.raw).to.equal('12-3456789');
+      });
+  });
+
+  test.it('prevents extra digits from being entered', function() {
+    helpers.setInput('12-3456789|', input);
+
+    input.sendKeys('0');
+
+    return helpers.getFieldKitValues()
+      .then(function(values) {
+        expect(values.raw).to.equal('12-3456789');
+      });
+  });
+
+  test.it('prevents entering non-digit characters', function() {
+    helpers.setInput('|', input);
+
+    input.sendKeys('f');
+
+    return helpers.getFieldKitValues()
+      .then(function(values) {
+        expect(values.raw).to.equal('');
+      });
+  });
+
+  test.it('backspaces words correctly', function() {
+    helpers.setInput('12-3456789|', input);
+
+    input.sendKeys(Key.chord(Key.ALT, Key.BACK_SPACE));
+
+    return helpers.getFieldKitValues()
+      .then(function(values) {
+        expect(values.raw).to.equal('12-');
+      });
+  });
+});
+

--- a/test/selenium/server/test_pages/employer_identification_number_formatter.html
+++ b/test/selenium/server/test_pages/employer_identification_number_formatter.html
@@ -1,0 +1,13 @@
+<html>
+  <head>
+    <script src="/jquery-caret/jquery.caret.js"></script>
+    <script src="/field-kit.js"></script>
+  </head>
+
+  <body>
+    <input id="field" />
+    <script>
+      window.testField = new FieldKit.TextField(document.getElementById('field'), new FieldKit.EmployerIdentificationNumberFormatter());
+    </script>
+  </body>
+</html>

--- a/test/unit/employer_identification_number_formatter_test.js
+++ b/test/unit/employer_identification_number_formatter_test.js
@@ -1,0 +1,28 @@
+import { expectThatTyping } from './helpers/expectations';
+import { buildField } from './helpers/builders';
+import FieldKit from '../../src';
+
+testsWithAllKeyboards('FieldKit.EmployerIdentificationNumberFormatter', function() {
+  var field;
+
+  beforeEach(function() {
+    field = buildField();
+    field.setFormatter(new FieldKit.EmployerIdentificationNumberFormatter());
+  });
+
+  it('places dashes in the right places', function() {
+    expectThatTyping('123456789').into(field).willChange('|').to('12-3456789|');
+  });
+
+  it('prevents extra digits from being entered', function() {
+    expectThatTyping('0').into(field).willNotChange('12-3456789|');
+  });
+
+  it('prevents entering non-digit characters', function() {
+    expectThatTyping('f').into(field).willNotChange('|');
+  });
+
+  it('backspaces words correctly', function() {
+    expectThatTyping('alt+backspace').into(field).willChange('12-3456789|').to('12-|');
+  });
+});


### PR DESCRIPTION
EIN's are useful for business-related concerns (taxes, payroll, etc.). 

It'd be nice if there were a simple way to determine whether a TIN is actually an SSN versus an EIN, but the numeric spaces of the two overlap (both consist of nine digits).

If you have ideas for obvious refactorings to combine EIN and SSN into a common TIN class, I'm open to them, but I'm not sure it's worth it for such a simple class.