### PR TITLE
Add memoization for expensive calls in number formatter

### DIFF
--- a/src/number_formatter.js
+++ b/src/number_formatter.js
@@ -134,6 +134,7 @@ function replaceMinusSign(string, minusSign) {
 class NumberFormatter extends Formatter {
   constructor() {
     super();
+    this._defaultCache = {};
     this.setNumberStyle(NONE);
   }
 
@@ -196,6 +197,7 @@ class NumberFormatter extends Formatter {
    */
   setCountryCode(countryCode) {
     this._countryCode = countryCode;
+    this._defaultCache = {};
     return this;
   }
 
@@ -216,6 +218,7 @@ class NumberFormatter extends Formatter {
    */
   setCurrencyCode(currencyCode) {
     this._currencyCode = currencyCode;
+    this._defaultCache = {};
     return this;
   }
 
@@ -379,6 +382,7 @@ class NumberFormatter extends Formatter {
    */
   setLocale(locale) {
     this._locale = locale;
+    this._defaultCache = {};
     return this;
   }
 
@@ -912,10 +916,25 @@ class NumberFormatter extends Formatter {
    * @private
    */
   _get(attr) {
-    let value = this['_' + attr];
+    const attrKey = '_' + attr;
+    let value = this[attrKey];
     if (value !== null && value !== undefined) {
       return value;
     }
+    if (this._defaultCache[attrKey]) {
+      return this._defaultCache[attrKey];
+    }
+    let result = this.getFromDefaults(attr);
+    this._defaultCache[attrKey] = result;
+    return result;
+  }
+
+  /**
+   * @param {string} attr
+   * @returns {*}
+   * @private
+   */
+  getFromDefaults(attr) {
     const styleDefaults = this._styleDefaults;
     const localeDefaults = this._localeDefaults();
     const regionDefaults = this._regionDefaults();
@@ -1286,6 +1305,9 @@ class NumberFormatter extends Formatter {
    * @private
    */
   _currencyDefaults() {
+    if (this._defaultCache.currencyDefaults) {
+      return this._defaultCache.currencyDefaults;
+    }
     const result = {};
 
     forEach(CurrencyDefaults['default'], function(value, key) {
@@ -1296,6 +1318,7 @@ class NumberFormatter extends Formatter {
       result[key] = value;
     });
 
+    this._defaultCache.currencyDefaults = result;
     return result;
   }
 
@@ -1326,6 +1349,10 @@ class NumberFormatter extends Formatter {
    * @private
    */
   _localeDefaults() {
+    if (this._defaultCache.localeDefaults) {
+      return this._defaultCache.localeDefaults;
+    }
+
     const locale = this.locale();
     const countryCode = this.countryCode();
     const lang = splitLocaleComponents(locale).lang;
@@ -1345,6 +1372,7 @@ class NumberFormatter extends Formatter {
       });
     });
 
+    this._defaultCache.localeDefaults = result;
     return result;
   }
 }
@@ -1397,6 +1425,8 @@ NumberFormatter.prototype._roundingMode = null;
 NumberFormatter.prototype._usesGroupingSeparator = null;
 /** @private */
 NumberFormatter.prototype._zeroSymbol = null;
+/** @private */
+NumberFormatter.prototype._defaultCache = null;
 
 /**
  * Aliases

--- a/src/number_formatter.js
+++ b/src/number_formatter.js
@@ -995,29 +995,21 @@ class NumberFormatter extends Formatter {
       return '';
     }
 
-    const zeroSymbol = this.zeroSymbol();
-    if (zeroSymbol !== undefined && zeroSymbol !== null && number === 0) {
-      return zeroSymbol;
+    let symbol;
+    if (number === 0) {
+      symbol = this.zeroSymbol();
+    } else if (number === null) {
+      symbol = this.nullSymbol();
+    } else if (isNaN(number)) {
+      symbol = this.notANumberSymbol();
+    } else if (number === Infinity) {
+      symbol = this.positiveInfinitySymbol();
+    } else if (number === -Infinity) {
+      symbol = this.negativeInfinitySymbol();
     }
 
-    const nullSymbol = this.nullSymbol();
-    if (nullSymbol !== undefined && nullSymbol !== null && number === null) {
-      return nullSymbol;
-    }
-
-    const notANumberSymbol = this.notANumberSymbol();
-    if (notANumberSymbol !== undefined && notANumberSymbol !== null && isNaN(number)) {
-      return notANumberSymbol;
-    }
-
-    const positiveInfinitySymbol = this.positiveInfinitySymbol();
-    if (positiveInfinitySymbol !== undefined && positiveInfinitySymbol !== null && number === Infinity) {
-      return positiveInfinitySymbol;
-    }
-
-    const negativeInfinitySymbol = this.negativeInfinitySymbol();
-    if (negativeInfinitySymbol !== undefined && negativeInfinitySymbol !== null && number === -Infinity) {
-      return negativeInfinitySymbol;
+    if (symbol !== undefined && symbol !== null) {
+      return symbol;
     }
 
     let negative = number < 0;


### PR DESCRIPTION
Some of the number formatter methods are becoming performance bottlenecks - e.g. computing _localeDefaults requires a nested loop to extract a map, of which one value is used.

Memoizing these makes this more performant for clients that reuse number formatters.